### PR TITLE
Support more step definitions

### DIFF
--- a/src/main/kotlin/net/lagerwey/plugins/cucumber/kotlin/KotlinCucumberExtension.kt
+++ b/src/main/kotlin/net/lagerwey/plugins/cucumber/kotlin/KotlinCucumberExtension.kt
@@ -68,7 +68,7 @@ class KotlinCucumberExtension : AbstractCucumberExtension() {
         val result = mutableListOf<AbstractStepDefinition>()
         val dependenciesScope = module.moduleContentWithDependenciesScope
         val kotlinFiles = GlobalSearchScope.getScopeRestrictedByFileTypes(dependenciesScope, KotlinFileType.INSTANCE)
-        for (method in arrayOf("Given", "And", "Then", "But", "When")) {
+        for (method in (featureFile as GherkinFile).stepKeywords.filter { it != "*" }) {
             val occurrencesProcessor: (PsiElement, Int) -> Boolean = { element, _ ->
                 val parent = element.parent
                 if (parent != null) {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -28,7 +28,7 @@
     </change-notes>
 
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
-    <idea-version since-build="162"/>
+    <idea-version since-build="182.711"/>
 
     <depends>gherkin</depends>
     <depends>org.jetbrains.kotlin</depends>


### PR DESCRIPTION
Find step definitions for all supported languages (by using the locale dependent step keywords of the gherkin file).

Support [cucumber expressions](https://cucumber.io/docs/cucumber/cucumber-expressions/). Only basic support. No support added for custom types.
