### PR TITLE
Vendor CucumberUtil.isCucumberExpression

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,8 @@
-import org.gradle.internal.impldep.org.apache.maven.wagon.PathUtils.password
 import org.jetbrains.intellij.tasks.PublishTask
-import org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 buildscript {
-    extra["kotlinVersion"] = "1.3.10"
+    extra["kotlinVersion"] = "1.3.31"
 
     repositories {
         mavenCentral()
@@ -16,8 +14,8 @@ buildscript {
 }
 plugins {
     base
-    kotlin("jvm") version "1.3.10"
-    id ("org.jetbrains.intellij") version "0.3.12"
+    kotlin("jvm") version "1.3.31"
+    id ("org.jetbrains.intellij") version "0.4.8"
 }
 val kotlinVersion = extra["kotlinVersion"] as String
 
@@ -28,12 +26,15 @@ apply {
 intellij {
     pluginName = "cucumber-kotlin"
     version = "2018.3"
+//    version = "2019.1.3"
     downloadSources = true
     updateSinceUntilBuild = false //Disables updating since-build attribute in plugin.xml
 
     setPlugins(
         "gherkin:183.4284.148",
+//        "gherkin:191.6707.7",
         "org.jetbrains.kotlin:$kotlinVersion-release-IJ2018.3-1"
+//        "org.jetbrains.kotlin:$kotlinVersion-release-IJ2019.1-1"
     )
 }
 

--- a/src/main/kotlin/net/lagerwey/plugins/cucumber/kotlin/steps/KotlinStepDefinition.kt
+++ b/src/main/kotlin/net/lagerwey/plugins/cucumber/kotlin/steps/KotlinStepDefinition.kt
@@ -12,7 +12,7 @@ class KotlinStepDefinition(method: PsiElement) : AbstractStepDefinition(method) 
 
     override fun getCucumberRegexFromElement(element: PsiElement?): String? {
         val text = stepDefinitionText ?: return null
-        return if (CucumberUtil.isCucumberExpression(text)) {
+        return if (isCucumberExpression(text)) {
             CucumberUtil.buildRegexpFromCucumberExpression(text, MapParameterTypeManager.DEFAULT)
         } else {
             text

--- a/src/main/kotlin/net/lagerwey/plugins/cucumber/kotlin/steps/VendoredCucumberUtil.kt
+++ b/src/main/kotlin/net/lagerwey/plugins/cucumber/kotlin/steps/VendoredCucumberUtil.kt
@@ -1,0 +1,42 @@
+package net.lagerwey.plugins.cucumber.kotlin.steps
+
+import com.intellij.openapi.util.text.StringUtil
+import org.jetbrains.plugins.cucumber.CucumberUtil
+
+// Vendored code due to removal of isCucumberExpression in 2019.1 versions of the gherkin plugin
+// isCucumberExpression was later restored, so this can be deleted down the line
+// See https://github.com/jlagerweij/cucumber-kotlin/issues/7 for details
+
+// https://github.com/JetBrains/intellij-plugins/blob/9338364a06/cucumber/src/org/jetbrains/plugins/cucumber/CucumberUtil.java#L336
+fun isCucumberExpression(stepDefinitionPattern: String): Boolean {
+    if (stepDefinitionPattern.startsWith("^") && stepDefinitionPattern.endsWith("$")) {
+        return false
+    }
+    val containsParameterTypes = booleanArrayOf(false)
+    CucumberUtil.processParameterTypesInCucumberExpression(stepDefinitionPattern) { textRange ->
+        if (textRange.length < 2) {
+            // at least "{}" expected here
+            return@processParameterTypesInCucumberExpression true
+        }
+        val parameterTypeCandidate = stepDefinitionPattern.substring(textRange.startOffset + 1, textRange.endOffset - 1)
+        if (!isNotNegativeNumber(parameterTypeCandidate) && !parameterTypeCandidate.contains(",")) {
+            containsParameterTypes[0] = true
+        }
+        true
+    }
+
+    return containsParameterTypes[0]
+}
+
+// From 2019.1 version of com.intellij.openapi.util.text.StringUtil (i.e. not available in 2018.3):
+private fun isNotNegativeNumber(s: CharSequence?): Boolean {
+    if (s == null) {
+        return false
+    }
+    for (i in 0 until s.length) {
+        if (!StringUtil.isDecimalDigit(s[i])) {
+            return false
+        }
+    }
+    return true
+}


### PR DESCRIPTION
* 78c9672 Bump gradle deps to for testing of newer IntelliJ
	Now commented versions should probably be set up for easy switching
and building on CI. Inspiration could probably be taken from e.g.
[intellij-rust](https://github.com/intellij-rust/intellij-rust)
* dfe0ff1 Vendor CucumberUtil.isCucumberExpression
	To fix NoSuchMethodError on 2019.1. Fixes #7