### PR TITLE
Add support for JVM types

### DIFF
--- a/src/main/kotlin/net/lagerwey/plugins/cucumber/kotlin/steps/KotlinParameterTypeManager.kt
+++ b/src/main/kotlin/net/lagerwey/plugins/cucumber/kotlin/steps/KotlinParameterTypeManager.kt
@@ -6,11 +6,23 @@ import org.jetbrains.plugins.cucumber.CucumberUtil
 import org.jetbrains.plugins.cucumber.ParameterTypeManager
 
 object KotlinParameterTypeManager : ParameterTypeManager {
+
+    private const val defaultIntegerPattern = "-?\\d+"
+    private const val defaultDecimalPattern = "-?\\d*[.,]?\\d+"
+    private val defaultJvmParameterTypes = mapOf(
+            "biginteger" to defaultIntegerPattern,
+            "bigdecimal" to defaultDecimalPattern,
+            "byte" to defaultIntegerPattern,
+            "short" to defaultIntegerPattern,
+            "long" to defaultIntegerPattern,
+            "double" to defaultDecimalPattern
+    )
     private val nameToParameterTypeMap = mutableMapOf<String, String>()
     private val nameToDeclarationMap = mutableMapOf<String, SmartPsiElementPointer<PsiElement>>()
 
     init {
         nameToParameterTypeMap.putAll(CucumberUtil.STANDARD_PARAMETER_TYPES)
+        nameToParameterTypeMap.putAll(defaultJvmParameterTypes)
     }
 
     fun addParameterType(name: String, parameterType: String, declaration: SmartPsiElementPointer<PsiElement>) {


### PR DESCRIPTION
Hello, just testing the plugin with the example module provided [here](https://github.com/cucumber/cucumber-jvm/tree/main/kotlin-java8) I noticed the step with the `{long}` expression was not recognized.

As stated on cucumber docs, JVM implementation supports additional parameter types:
biginteger, bigdecimal, byte, short, long and double.

See https://cucumber.io/docs/cucumber/cucumber-expressions/#parameter-types